### PR TITLE
Update extension for spaCy 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![license](https://img.shields.io/github/license/mashape/apistatus.svg?maxAge=2592000)](https://github.com/Liebeck/spacy-sentiws/master/LICENSE.md)
 [![Build Status](https://api.travis-ci.org/Liebeck/spacy-sentiws.svg?branch=master)](https://travis-ci.org/Liebeck/spacy-sentiws)
 
-This package uses the [spaCy 2.0 extensions](https://spacy.io/usage/processing-pipelines#extensions) to add [SentiWS](http://wortschatz.uni-leipzig.de/en/download) as German sentiment score directly into your spaCy pipeline.
+This package uses the [spaCy 3 extensions](https://spacy.io/usage/processing-pipelines#extensions) to add [SentiWS](http://wortschatz.uni-leipzig.de/en/download) as German sentiment score directly into your spaCy pipeline.
 
 
 ## Usage
@@ -11,8 +11,7 @@ import spacy
 from spacy_sentiws import spaCySentiWS
 
 nlp = spacy.load('de')
-sentiws = spaCySentiWS(sentiws_path='data/sentiws/')
-nlp.add_pipe(sentiws)
+nlp.add_pipe('sentiws', config={'sentiws_path': 'data/sentiws/'})
 doc = nlp('Die Dummheit der Unterwerfung blüht in hübschen Farben.')
 
 for token in doc:

--- a/spacy_sentiws/__init__.py
+++ b/spacy_sentiws/__init__.py
@@ -1,6 +1,11 @@
 from spacy.tokens import Token
 from spacy_sentiws.senti_ws_wrapper import SentiWSWrapper
+from spacy.language import Language
 
+
+@Language.factory("sentiws")
+def create_component(nlp: Language, name, sentiws_path):
+    return spaCySentiWS(sentiws_path=sentiws_path)
 
 class spaCySentiWS(object):
     def __init__(self, sentiws_path):


### PR DESCRIPTION
This updates the extension to support spaCy 3.

The component is registered with the spaCy `Language.factory` decorator by name ("sentiws"). Usage changes slightly, the user does not need to initialize an spaCySentiWS instance but instead references the component by name in `add_pipe()` and pass the data path in an object in the `config` parameter.

Fixes #3 